### PR TITLE
Added authors key; cleaned up

### DIFF
--- a/ex.tex
+++ b/ex.tex
@@ -15,6 +15,7 @@
 	course={Master Thesis},
 	institute={Radboud Universiteit Nijmegen},
 	authorstext={Auteurs:},
+	authors={J. Doe},
 	righttextheader={Supervisors:},
 	righttext={Jane Doe}]
 

--- a/rutitlepage.sty
+++ b/rutitlepage.sty
@@ -8,10 +8,11 @@
 % - Make CTAN ready
 \RequirePackage{graphicx,ifpdf,keyval}
 
-\makeatletter
+\def\@rutitleauthors{\@author}
 \define@key{maketitleru}{course}{\def\@rutitlecourse{#1}}
 \define@key{maketitleru}{institute}{\def\@rutitleinst{#1}}
 \define@key{maketitleru}{authorstext}{\def\@rutitleauthorstext{#1}}
+\define@key{maketitleru}{authors}{\def\@rutitleauthors{#1}}
 \define@key{maketitleru}{righttext}{\def\@rutitlerighttext{#1}}
 \define@key{maketitleru}{righttextheader}{\def\@rutitlerighttextheader{#1}}
 \setkeys{maketitleru}{%
@@ -40,7 +41,7 @@
 			\begin{minipage}[t]{0.45\textwidth}
 				\begin{flushleft}\large
 					\textit{\@rutitleauthorstext}\\
-					\@author{}
+					\@rutitleauthors{}
 				\end{flushleft}
 			\end{minipage}
 			\begin{minipage}[t]{0.45\textwidth}
@@ -55,4 +56,3 @@
 		\makeatother
 	\end{titlepage}
 }
-\makeatother


### PR DESCRIPTION
- The `authors` key is useful for document classes like `amsart` that don't set `\@author`.
- `\makeatletter` and `\makeatother` are not needed in style files