### PR TITLE
Added pagenr option and equal margins in twoside documents

### DIFF
--- a/ex.tex
+++ b/ex.tex
@@ -17,6 +17,7 @@
 	authorstext={Auteurs:},
 	authors={J. Doe},
 	righttextheader={Supervisors:},
-	righttext={Jane Doe}]
+	righttext={Jane Doe},
+	pagenr=1]
 
 \end{document}

--- a/rutitlepage.sty
+++ b/rutitlepage.sty
@@ -6,15 +6,17 @@
 % - Internationalize (dutch logos)
 % - Nice document
 % - Make CTAN ready
-\RequirePackage{graphicx,ifpdf,keyval}
+\RequirePackage{geometry,graphicx,ifpdf,keyval}
 
 \def\@rutitleauthors{\@author}
+\def\@rutitlepagenr{\thepage}
 \define@key{maketitleru}{course}{\def\@rutitlecourse{#1}}
 \define@key{maketitleru}{institute}{\def\@rutitleinst{#1}}
 \define@key{maketitleru}{authorstext}{\def\@rutitleauthorstext{#1}}
 \define@key{maketitleru}{authors}{\def\@rutitleauthors{#1}}
 \define@key{maketitleru}{righttext}{\def\@rutitlerighttext{#1}}
 \define@key{maketitleru}{righttextheader}{\def\@rutitlerighttextheader{#1}}
+\define@key{maketitleru}{pagenr}{\def\@rutitlepagenr{#1}}
 \setkeys{maketitleru}{%
 	course={},
 	institute={Radboud University Nijmegen},
@@ -24,8 +26,9 @@
 }	
 \newcommand{\maketitleru}[1][]{
 	\setkeys{maketitleru}{#1}
+	\newgeometry{hmarginratio=1:1}
 	\begin{titlepage}
-		\makeatletter
+		\setcounter{page}{\@rutitlepagenr}
 		\begin{center}
 			\textsc{\LARGE\@rutitlecourse}\\[1.5cm]
 			\ifpdf\includegraphics[height=150pt]{logo.pdf}\\
@@ -53,6 +56,6 @@
 			\vfill
 			{\large\@date}
 		\end{center}
-		\makeatother
 	\end{titlepage}
+	\restoregeometry
 }


### PR DESCRIPTION
`\titlepage` sets the `page` counter to zero, so if you don't want this, an option is the only way to override it.

In `twoside` documents, the inner and outer margins are unequal, but on a title page you typically don't want this.