### PR TITLE
Fix multi-line title rendering in 17 and 22 layouts

### DIFF
--- a/rutitlepage.dtx
+++ b/rutitlepage.dtx
@@ -200,7 +200,7 @@
 		\null\vfill%
 		\parindent0pt
 		\ifdefined\@rutitlecourse\textsc{\LARGE\@rutitlecourse}\\[1.5cm]\fi
-		{\Huge\bfseries\@rutitletitle}%
+		\parbox{\textwidth}{\raggedright\Huge\bfseries\@rutitletitle}%
 		\ifdefined\@rutitlesubtitle{\\[2\baselineskip]\large\itshape\@rutitlesubtitle\/}\fi\\[4\baselineskip]
 		{\Large\scshape\@rutitleauthors}\\[\baselineskip]
 		{\large\@rutitledate}
@@ -221,7 +221,7 @@
 	\begin{titlepage}%
 		\null\vfill%
 		\parindent0pt
-		{\Huge\bfseries\@rutitletitle}%
+		\parbox{\textwidth}{\raggedright\Huge\bfseries\@rutitletitle}%
 		\ifdefined\@rutitlesubtitle{\\[2\baselineskip]\large\itshape\@rutitlesubtitle\/}\fi\\[4\baselineskip]
 		{\Large\scshape\@rutitleauthors}\\[\baselineskip]
 		{\large\@rutitledate}


### PR DESCRIPTION
Use a parbox with raggedright so a multi-line title will correctly apply leading.

Before this patch subsequent title lines are rendered vertically stacked too closely, because the no 'leading' (vertical white space between subsequent lines) is applied. The breaking of long titles is also somehow affected (I would say improved).

Fixes #17